### PR TITLE
Add basic fermion-sim tests

### DIFF
--- a/sample_fermion.py
+++ b/sample_fermion.py
@@ -17,13 +17,24 @@ def orthogonal_from_hamiltonian(A: np.ndarray) -> np.ndarray:
 
 def covariance_from_occupation(occ, N: int) -> np.ndarray:
     """
-    Build the 2N×2N Majorana covariance matrix Γ corresponding to
-    the Fock state with occupied mode indices in *occ*.
+    Build the 2N×2N Majorana covariance matrix ``Γ`` corresponding to the
+    Fock state with occupied mode indices in ``occ``.
+
+    The covariance matrix is block diagonal with 2×2 blocks
+
+    ``[[0,  s], [-s, 0]]``
+
+    where ``s = +1`` for an occupied mode and ``s = -1`` for an unoccupied
+    mode.
     """
+    if N < 0:
+        raise ValueError("N must be non‑negative")
+
     Γ = np.zeros((2 * N, 2 * N))
-    for p in occ:
-        Γ[2 * p,     2 * p + 1] =  1
-        Γ[2 * p + 1, 2 * p    ] = -1
+    for j in range(N):
+        s = 1 if j in occ else -1
+        Γ[2 * j,     2 * j + 1] =  s
+        Γ[2 * j + 1, 2 * j    ] = -s
     return Γ
 
 
@@ -94,7 +105,7 @@ def sample_evolved_state(occ, U: np.ndarray) -> str:
     Take an initial occupation list *occ*, evolve with orbital unitary U,
     and return one measurement outcome as a bit-string (big-endian).
     """
-    N = len(occ)
+    N = U.shape[0]
     O = orbital_to_majorana_rotation(U)
     Γ = covariance_from_occupation(occ, N)
     Γ_evolved = evolve_covariance(Γ, O)

--- a/tests/test_sample_fermion.py
+++ b/tests/test_sample_fermion.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from sample_fermion import (
+    majorana_hamiltonian,
+    orthogonal_from_hamiltonian,
+    covariance_from_occupation,
+    evolve_covariance,
+    orbital_to_majorana_rotation,
+    sample_fermion_state,
+    get_bitstring_probs_from_covariance,
+    sample_evolved_state,
+)
+
+
+def test_majorana_hamiltonian_antisymmetric():
+    rng = np.random.default_rng(123)
+    x = rng.normal(size=(4, 4))
+    A = majorana_hamiltonian(x)
+    assert np.allclose(A, -A.T)
+
+
+def test_orthogonal_from_hamiltonian():
+    rng = np.random.default_rng(456)
+    x = rng.normal(size=(6, 6))
+    A = majorana_hamiltonian(x)
+    O = orthogonal_from_hamiltonian(A)
+    eye = np.eye(O.shape[0])
+    assert np.allclose(O @ O.T, eye, atol=1e-12)
+
+
+def test_orbital_to_majorana_rotation_orthogonal():
+    rng = np.random.default_rng(789)
+    X = rng.normal(size=(3, 3)) + 1j * rng.normal(size=(3, 3))
+    U, _ = np.linalg.qr(X)
+    O = orbital_to_majorana_rotation(U)
+    eye = np.eye(O.shape[0])
+    assert np.allclose(O @ O.T, eye, atol=1e-12)
+
+
+def test_evolve_covariance_preserves_antisymmetry():
+    rng = np.random.default_rng(101)
+    x = rng.normal(size=(4, 4))
+    A = majorana_hamiltonian(x)
+    O = orthogonal_from_hamiltonian(A)
+    Gamma = A  # any antisymmetric matrix works as a covariance analogue
+    evolved = evolve_covariance(Gamma, O)
+    assert np.allclose(evolved, -evolved.T, atol=1e-12)
+
+
+def test_covariance_from_occupation_blocks():
+    N = 3
+    occ = [0, 2]
+    Gamma = covariance_from_occupation(occ, N)
+    for j in range(N):
+        block = Gamma[2 * j : 2 * j + 2, 2 * j : 2 * j + 2]
+        expected = 1 if j in occ else -1
+        ref = np.array([[0, expected], [-expected, 0]])
+        assert np.array_equal(block, ref)
+
+
+def test_sampling_matches_probabilities():
+    N = 2
+    occ = [1]
+    Gamma = covariance_from_occupation(occ, N)
+    probs = get_bitstring_probs_from_covariance(Gamma)
+    counts = {i: 0 for i in range(len(probs))}
+    for _ in range(2000):
+        bitstr = sample_fermion_state(Gamma)
+        idx = int(bitstr, 2)
+        counts[idx] += 1
+    freq = np.array([counts[i] / 2000 for i in range(len(probs))])
+    assert np.allclose(freq, probs, atol=0.1)
+
+
+def test_sample_evolved_state_length():
+    N = 4
+    occ = [0, 1]
+    U = np.eye(N)
+    out = sample_evolved_state(occ, U)
+    assert isinstance(out, str)
+    assert len(out) == N


### PR DESCRIPTION
## Summary
- improve covariance generation for occupations
- fix `sample_evolved_state` dimension logic
- add a pytest suite covering helper functions and sampling

## Testing
- `pytest -q`