### PR TITLE
Fix sampling to preserve particle number

### DIFF
--- a/tests/test_sample_fermion.py
+++ b/tests/test_sample_fermion.py
@@ -75,6 +75,13 @@ class TestFermionSampler(unittest.TestCase):
         self.assertIsInstance(out, str)
         self.assertEqual(len(out), N)
 
+    def test_fock_state_sampling_deterministic(self):
+        N = 4
+        occ = [1, 2]
+        Gamma = covariance_from_occupation(occ, N)
+        for _ in range(10):
+            self.assertEqual(sample_fermion_state(Gamma), "0110")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- correct formula for particle-sector correlator in `sample_fermion_state`
- fix `get_bitstring_probs_from_covariance` and its recursion for deterministic modes
- add regression test for deterministic Fock-state sampling

## Testing
- `PYTHONPATH=. pytest -q`